### PR TITLE
Add CLI initialization in class-monitor

### DIFF
--- a/inc/class-monitor.php
+++ b/inc/class-monitor.php
@@ -101,6 +101,7 @@ class Monitor {
 		}
 
 		new Misc( $this->registry, $namespace );
+		new CLI( $this->registry );
 	}
 
 	/**


### PR DESCRIPTION
Fixes: 

wp prompress storage wipe
Error: 'prompress' is not a registered wp command. See 'wp help' for available commands.