### PR TITLE
Added API key authentication alternative.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 	},
 	"scripts": {
 		"lint": "php ./vendor/bin/phpcs -ps .",
-		"make-pot": "./vendor/bin/wp make-pot ./ languages/prompress.pot --domain=prompress"
+		"make-pot": "./vendor/bin/wp i18n make-pot ./ languages/prompress.pot --domain=prompress"
 	},
 	"config": {
 		"sort-packages": true,

--- a/inc/admin-page.php
+++ b/inc/admin-page.php
@@ -46,6 +46,12 @@ function register_page() {
  */
 function render_page() {
 	?>
+	<script>
+		var prompress = {
+			settings: <?php echo wp_json_encode( get_settings() ); ?>,
+			configTemplate: <?php echo wp_json_encode( get_prometheus_config_template() ) . "\n"; ?>
+		};
+	</script>
 	<div id="prompress-plugin-settings"></div>
 	<?php
 }


### PR DESCRIPTION
For those who have `wpackagist-plugin/jwt-authentication-for-wp-rest-api` installed, Bearer token authentication is problematic, because the plugin intercepts the token and tries to authenticate the user automatically.

To make it work, you need to:

1. Create an unprivileged user.
2. add_filter to increase the token TTL.
3. Login them.
4. Store a long-lived token for this user.

Authentication via a specific header simplifies things a lot.

In this same commit, I pass the settings into a `<script>` before the settings page `<div>`. This saves a request. If, for some reason, the data is missing, an AJAX request will be sent (old method).

Added a dynamic Prometheus job-config example to the bottom of the settings page.