### PR TITLE
Drop empty counts in prompress_posts_total.

### DIFF
--- a/inc/class-posts.php
+++ b/inc/class-posts.php
@@ -88,6 +88,9 @@ class Posts {
 			$counts = \wp_count_posts( $post_type );
 
 			foreach ( $counts as $status => $count ) {
+                if ( ! $count ) {
+                    continue;
+                }
 				$this->posts->set(
 					(int) $count,
 					[


### PR DESCRIPTION
On. installations with many posts_statuses and/or post_types we have too many zero values.
Do we need them?